### PR TITLE
Add params for 'partitioned' in `set_cookie()` and `delete_cookie()`

### DIFF
--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -194,6 +194,7 @@ class Response:
         secure: bool = False,
         httponly: bool = False,
         samesite: str | None = None,
+        partitioned: bool = False,
     ) -> None:
         """Sets a cookie.
 
@@ -218,6 +219,7 @@ class Response:
         :param httponly: Disallow JavaScript access to the cookie.
         :param samesite: Limit the scope of the cookie to only be
             attached to requests that are "same-site".
+        :param partitioned: If ``True``, the cookie will be partitioned.
         """
         self.headers.add(
             "Set-Cookie",
@@ -232,6 +234,7 @@ class Response:
                 httponly=httponly,
                 max_size=self.max_cookie_size,
                 samesite=samesite,
+                partitioned=partitioned,
             ),
         )
 
@@ -243,6 +246,7 @@ class Response:
         secure: bool = False,
         httponly: bool = False,
         samesite: str | None = None,
+        partitioned: bool = False,
     ) -> None:
         """Delete a cookie.  Fails silently if key doesn't exist.
 
@@ -256,6 +260,7 @@ class Response:
         :param httponly: Disallow JavaScript access to the cookie.
         :param samesite: Limit the scope of the cookie to only be
             attached to requests that are "same-site".
+        :param partitioned: If ``True``, the cookie will be partitioned.
         """
         self.set_cookie(
             key,
@@ -266,6 +271,7 @@ class Response:
             secure=secure,
             httponly=httponly,
             samesite=samesite,
+            partitioned=partitioned,
         )
 
     @property


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- It appears that while your [PR](https://github.com/pallets/werkzeug/pull/2855) opened to `pallets/werkzeug` partially adds support for partitioned cookies, when testing locally I got `TypeError: set_cookie() got an unexpected keyword argument 'partitioned'`. I believe this is because the `set_cookie()` and `delete_cookie()` functions are missing the parameters for partitioned. This seems to have solved the problem on my end and might be worth looking over/testing more thoroughly. 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
